### PR TITLE
New Tab Option for Ribbon Icon and Command Palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Middle mouse button click and meta + click of the ribbon icon open links in new tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Middle mouse button click and meta + click of the ribbon icon open links in new tab
+- Meta + enter of the command palette item opens the item in a new tab

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 An [Obsidian](https://obsidian.md/) plugin that creates tomorrow's daily note for preemptive planning.
 
+See the [changelog](/CHANGELOG.md) for the latest changes and updates.
+
 ## Requirements
 
 - Obsidian **v0.12.0+**.

--- a/src/extensions/daily-notes.ts
+++ b/src/extensions/daily-notes.ts
@@ -6,11 +6,11 @@ import {
 } from 'obsidian-daily-notes-interface';
 import { getNextDailyNoteDate } from '../core/dates';
 
-export async function openNextDailyNote(skipWeekends: boolean): Promise<void> {
+export async function openNextDailyNote(skipWeekends: boolean, newTab: boolean = false): Promise<void> {
   const date = getNextDailyNoteDate(skipWeekends);
   const note = await getOrCreateNextDailyNote(date)
   
-  if (note) openNote(note);
+  if (note) openNote(note, newTab);
 }
 
 async function getOrCreateNextDailyNote(date: moment.Moment): Promise<TFile | void> {
@@ -22,8 +22,8 @@ async function getOrCreateNextDailyNote(date: moment.Moment): Promise<TFile | vo
   return nextDailyNote
 }
 
-async function openNote(file: TFile): Promise<void> {
+async function openNote(file: TFile, newTab: boolean): Promise<void> {
   const { workspace } = window.app;
-  const leaf = workspace.getLeaf(false);
+  const leaf = workspace.getLeaf(newTab);
   await leaf.openFile(file, { active: true });
 }

--- a/src/extensions/daily-notes.ts
+++ b/src/extensions/daily-notes.ts
@@ -3,10 +3,14 @@ import {
   getAllDailyNotes,
   getDailyNote,
   createDailyNote,
+  appHasDailyNotesPluginLoaded,
 } from 'obsidian-daily-notes-interface';
 import { getNextDailyNoteDate } from '../core/dates';
+import { triggerDailyNotesDependencyNotice } from './notice';
 
 export async function openNextDailyNote(skipWeekends: boolean, newTab: boolean = false): Promise<void> {
+  if (!validateDailyNotesPluginLoaded()) return;
+
   const date = getNextDailyNoteDate(skipWeekends);
   const note = await getOrCreateNextDailyNote(date)
   
@@ -26,4 +30,13 @@ async function openNote(file: TFile, newTab: boolean): Promise<void> {
   const { workspace } = window.app;
   const leaf = workspace.getLeaf(newTab);
   await leaf.openFile(file, { active: true });
+}
+
+function validateDailyNotesPluginLoaded(): boolean {
+  if (!appHasDailyNotesPluginLoaded()) {
+    triggerDailyNotesDependencyNotice();
+    return false;
+  }
+
+  return true;
 }

--- a/src/handlers/command-handler.ts
+++ b/src/handlers/command-handler.ts
@@ -1,31 +1,55 @@
-import { appHasDailyNotesPluginLoaded } from 'obsidian-daily-notes-interface';
+import { Platform } from "obsidian";
 import TomorrowsDailyNote from "src";
-import { triggerDailyNotesDependencyNotice } from "src/extensions/notice";
 import { openNextDailyNote } from "src/extensions/daily-notes";
 
 export class CommandHandler {
   private plugin: TomorrowsDailyNote;
+  private systemModifierKeyPressed: boolean = false;
 
   constructor(plugin: TomorrowsDailyNote) {
     this.plugin = plugin;
   }
 
   setup() {
+    document.addEventListener('keydown', this.handleKeyDown.bind(this));
+    document.addEventListener('keyup', this.handleKeyUp.bind(this));
+
     this.plugin.addCommand({
       id: 'create-tomorrows-daily-note',
       name: 'Open tomorrow\'s daily note',
       checkCallback: (checking: boolean) => {
         if (!checking) {
-          if (!appHasDailyNotesPluginLoaded()) {
-            triggerDailyNotesDependencyNotice();
-            return;
-          } else {
-            openNextDailyNote(this.plugin.settings.skipWeekends);
-          }
+          openNextDailyNote(
+            this.plugin.settings.skipWeekends,
+            this.useNewTab()
+          );
         }
 
         return true
       }
     })
+  }
+
+  tearDown() {
+    document.removeEventListener('keydown', this.handleKeyDown.bind(this));
+    document.removeEventListener('keyup', this.handleKeyUp.bind(this));
+  }
+
+  handleKeyDown(event: KeyboardEvent) {
+    const systemMetaKey = Platform.isMacOS ? event.metaKey : event.ctrlKey;
+    if (systemMetaKey) {
+      this.systemModifierKeyPressed = true;
+    }
+  }
+
+  handleKeyUp(event: KeyboardEvent) {
+    const systemMetaKey = Platform.isMacOS ? event.metaKey : event.ctrlKey;
+    if (systemMetaKey) {
+      this.systemModifierKeyPressed = false;
+    }
+  }
+
+  useNewTab(): boolean {
+    return this.systemModifierKeyPressed;
   }
 }

--- a/src/handlers/ribbon-handler.ts
+++ b/src/handlers/ribbon-handler.ts
@@ -1,3 +1,4 @@
+import { Platform } from "obsidian";
 import { appHasDailyNotesPluginLoaded } from 'obsidian-daily-notes-interface';
 import TomorrowsDailyNote from "src";
 import { triggerDailyNotesDependencyNotice } from 'src/extensions/notice';
@@ -23,12 +24,14 @@ export class RibbonHandler {
       .addRibbonIcon(
         'calendar-plus',
         'Open tomorrow\'s daily note',
-        async () => {
+        async (event: MouseEvent) => {
           if (!appHasDailyNotesPluginLoaded()) {
             triggerDailyNotesDependencyNotice();
             return;
           } else {
-            await openNextDailyNote(this.plugin.settings.skipWeekends);
+            const metaKey = Platform.isMacOS ? event.metaKey : event.ctrlKey;
+            const newTab = event.button === 1 || metaKey;
+            await openNextDailyNote(this.plugin.settings.skipWeekends, newTab);
           }
         }
       )

--- a/src/handlers/ribbon-handler.ts
+++ b/src/handlers/ribbon-handler.ts
@@ -1,7 +1,5 @@
 import { Platform } from "obsidian";
-import { appHasDailyNotesPluginLoaded } from 'obsidian-daily-notes-interface';
 import TomorrowsDailyNote from "src";
-import { triggerDailyNotesDependencyNotice } from 'src/extensions/notice';
 import { openNextDailyNote } from 'src/extensions/daily-notes';
 
 export const RIBBON_ICON_ID = 'tomorrows-daily-note-ribbon-icon';
@@ -25,14 +23,10 @@ export class RibbonHandler {
         'calendar-plus',
         'Open tomorrow\'s daily note',
         async (event: MouseEvent) => {
-          if (!appHasDailyNotesPluginLoaded()) {
-            triggerDailyNotesDependencyNotice();
-            return;
-          } else {
-            const metaKey = Platform.isMacOS ? event.metaKey : event.ctrlKey;
-            const newTab = event.button === 1 || metaKey;
-            await openNextDailyNote(this.plugin.settings.skipWeekends, newTab);
-          }
+          await openNextDailyNote(
+            this.plugin.settings.skipWeekends,
+            this.useNewTab(event)
+          );
         }
       )
       .setAttribute("id", RIBBON_ICON_ID)
@@ -42,5 +36,10 @@ export class RibbonHandler {
     document
       .getElementById(RIBBON_ICON_ID)
       ?.remove();
+  }
+
+  useNewTab(event: MouseEvent): boolean {
+    const systemMetaKey = Platform.isMacOS ? event.metaKey : event.ctrlKey;
+    return event.button === 1 || systemMetaKey;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export default class TomorrowsDailyNote extends Plugin {
   settings: TomorrowsDailyNoteSettings;
   commandHandler: CommandHandler;
   ribbonHandler: RibbonHandler;
+  cmdPressed: boolean = false;
 
   async onload() {
     console.log("Loading plugin: Tomorrow's Daily Note")
@@ -29,6 +30,7 @@ export default class TomorrowsDailyNote extends Plugin {
 
 	onunload() {
     console.log("Unloading plugin: Tomorrow's Daily Note")
+    this.commandHandler.tearDown()
   }
 
   async loadSettings() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export default class TomorrowsDailyNote extends Plugin {
   settings: TomorrowsDailyNoteSettings;
   commandHandler: CommandHandler;
   ribbonHandler: RibbonHandler;
-  cmdPressed: boolean = false;
 
   async onload() {
     console.log("Loading plugin: Tomorrow's Daily Note")


### PR DESCRIPTION
This pull request includes an update allowing tomorrow's note to be opened in anew tab from the ribbon icon and command palette.

## New Features:
* [`src/extensions/daily-notes.ts`](diffhunk://#diff-3e871df96c5e6b310dbd85bbb701bd8308148cdbb4309917b57f74bf52d1cf5cR6-R17): Added support for opening notes in new tabs using the middle mouse button or the meta key. [[1]](diffhunk://#diff-3e871df96c5e6b310dbd85bbb701bd8308148cdbb4309917b57f74bf52d1cf5cR6-R17) [[2]](diffhunk://#diff-3e871df96c5e6b310dbd85bbb701bd8308148cdbb4309917b57f74bf52d1cf5cL25-R42)
* [`src/handlers/command-handler.ts`](diffhunk://#diff-e3522e6c281c7348014f30f5dd54e4475a897d76ce1772badc48b3c754b467eaL1-R54): Implemented event listeners to detect system modifier key presses to open notes in new tabs.

## Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R13): Created a changelog file to document all notable changes in the project.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8): Added a link to the changelog for users to easily access the latest changes and updates.