### PR TITLE
Fix/ribbon icon positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Resolve reordering of ribbon icon during application refreshes
+
 ## [1.2.0] - 2024-10-05
 
 ### Added

--- a/src/extensions/notice.ts
+++ b/src/extensions/notice.ts
@@ -1,5 +1,5 @@
 import { Notice } from "obsidian";
 
 export function triggerDailyNotesDependencyNotice() {
-  new Notice('Please enable the Daily Notes plugin to use this feature.')
+  new Notice('Please enable the "Daily Notes" plugin to use the "Tomorrow\'s Daily Note" plugin.')
 }

--- a/src/handlers/command-handler.ts
+++ b/src/handlers/command-handler.ts
@@ -8,6 +8,7 @@ export class CommandHandler {
 
   constructor(plugin: TomorrowsDailyNote) {
     this.plugin = plugin;
+    this.setup();
   }
 
   setup() {

--- a/src/handlers/ribbon-handler.ts
+++ b/src/handlers/ribbon-handler.ts
@@ -9,6 +9,7 @@ export class RibbonHandler {
 
   constructor(plugin: TomorrowsDailyNote) {
     this.plugin = plugin;
+    this.setup();
   }
 
   setup() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,20 +15,15 @@ export default class TomorrowsDailyNote extends Plugin {
   ribbonHandler: RibbonHandler;
 
   async onload() {
-    console.log("Loading plugin: Tomorrow's Daily Note")
 
     await this.loadSettings()
     
     this.commandHandler = new CommandHandler(this)
     this.ribbonHandler = new RibbonHandler(this)
-    this.triggerDependencyCheck(() => {
-      this.commandHandler.setup()
-      this.ribbonHandler.setup()
-    })
+    this.dependencyCheck()
   }
 
 	onunload() {
-    console.log("Unloading plugin: Tomorrow's Daily Note")
     this.commandHandler.tearDown()
   }
 
@@ -41,14 +36,11 @@ export default class TomorrowsDailyNote extends Plugin {
     await this.saveData(this.settings);
   }
 
-  triggerDependencyCheck(callback: () => void) {
+  dependencyCheck() {
     this.app.workspace.onLayoutReady(() => {
-      console.log("Checking for Daily Notes plugin")
       if (!appHasDailyNotesPluginLoaded()) {
         triggerDailyNotesDependencyNotice();
       }
-
-      callback()
     })
   }
 }


### PR DESCRIPTION
Currently whenever Obsidian reloads, the ribbon icon reorders itself. This was noticed here: https://github.com/frankolson/obsidian-tomorrows-daily-note/issues/14. This PR resolves that issue.

## Changes
- Ribbon Icon retains position after application refreshes
  - In order to make this possible, we can't prevent the ribbon icon and command form initializing even if the plugin dependencies are not met. This means that we are more reliant on dependency notices, but this is probably better user experience.
- Updated the dependency notice to indicate to the user that the notice is coming from this plugin